### PR TITLE
added prisma theme to parts of the app

### DIFF
--- a/packages/timelapse-visual/src/DashboardSelector/DashboardSelector.tsx
+++ b/packages/timelapse-visual/src/DashboardSelector/DashboardSelector.tsx
@@ -298,7 +298,7 @@ class DashboardSelector extends Component<DashboardSelectorProps, DashboardSelec
         );
 
         return (
-            <SplunkThemeProvider family="enterprise" colorScheme="dark" density="compact">
+            <SplunkThemeProvider family="prisma" colorScheme="dark" density="compact">
                 <div style={{ width: '100%' }}>
                     <StyledContainer style={{ width: '100%' }}>
                         <ColumnLayout gutter={1} style={{ width: '100%' }}>
@@ -317,7 +317,7 @@ class DashboardSelector extends Component<DashboardSelectorProps, DashboardSelec
                                         Welcome {this.state.realname},
                                         <br />
                                     </Heading>
-                                    <Heading level={2}>
+                                    <Heading level={3}>
                                         This app will allow you to generate dashboards with custom
                                         time inputs. If you have any questions, please visit the{' '}
                                         <Link
@@ -335,7 +335,7 @@ class DashboardSelector extends Component<DashboardSelectorProps, DashboardSelec
                             </ColumnLayout.Row>
                             <ColumnLayout.Row>
                                 <ColumnLayout.Column style={colStyle} span={5}>
-                                    <Heading level={2}>
+                                    <Heading level={3}>
                                         If you understand how to use this app, than you can get
                                         started by using the following form to build your custom
                                         dashboard URL:

--- a/packages/timelapse-visual/src/Documentation/Documentation.tsx
+++ b/packages/timelapse-visual/src/Documentation/Documentation.tsx
@@ -17,7 +17,7 @@ export const Documentation = () => {
                 backgroundColor: '#171D21',
             }}
         >
-            <SplunkThemeProvider family="enterprise" colorScheme="dark" density="compact">
+            <SplunkThemeProvider family="prisma" colorScheme="dark" density="compact">
                 <Heading>Getting started</Heading>
                 <P>
                     To get started using this app, visit the <Link to="start">Start</Link>{' '}

--- a/packages/timelapse-visual/src/TimelapseControls/TimelapseControls.tsx
+++ b/packages/timelapse-visual/src/TimelapseControls/TimelapseControls.tsx
@@ -47,6 +47,7 @@ interface TimelapseControlsState {
   width: number;
   height: number;
   dark: any;
+  family: any;
   leftOpen: boolean;
   error_ds_no__time: Array<unknown>;
   error_no_dash: boolean;
@@ -262,9 +263,12 @@ export default class TimelapseControls extends React.Component<{ name: string },
     super(props);
 
     let darktheme = false;
+    let enterprise = true;
     if (params.get("theme") === "dark") {
       darktheme = true;
     }
+ 
+
     this.state = {
       isPlaying: false,
       isReversing: false,
@@ -282,6 +286,7 @@ export default class TimelapseControls extends React.Component<{ name: string },
       width: 0,
       height: 0,
       dark: darktheme,
+      family: enterprise,
       leftOpen: false,
       error_ds_no__time: [],
       error_no_dash: false,
@@ -311,6 +316,7 @@ export default class TimelapseControls extends React.Component<{ name: string },
     this.handleSliderChange = this.handleSliderChange.bind(this);
     this.updateDataSources = this.updateDataSources.bind(this);
     this.handleDarkModeClick = this.handleDarkModeClick.bind(this);
+    this.handleThemeFamilyClick = this.handleThemeFamilyClick.bind(this);
     this.openLeftPanel = this.openLeftPanel.bind(this);
     this.handleRequestOpen = this.handleRequestOpen.bind(this);
     this.handlePanelChange = this.handlePanelChange.bind(this);
@@ -605,6 +611,10 @@ export default class TimelapseControls extends React.Component<{ name: string },
     this.setState({ dark: !this.state.dark });
   }
 
+  handleThemeFamilyClick() {
+    this.setState({ family: !this.state.family });
+  }
+
   handleRequestOpen(dockPosition) {
     if (dockPosition === "bottomOpen") {
       setBottomOpen(true);
@@ -694,7 +704,7 @@ export default class TimelapseControls extends React.Component<{ name: string },
         }
       >
         <SplunkThemeProvider
-          family="enterprise"
+          family={this.state.family ? "enterprise" : "prisma"}
           colorScheme={this.state.dark ? "dark" : "light"}
           density="compact"
         >
@@ -741,6 +751,14 @@ export default class TimelapseControls extends React.Component<{ name: string },
                         appearance="toggle"
                       >
                         Dark Mode
+                      </Switch>{" "}
+                      <Switch
+                        value="enterprise"
+                        onClick={this.handleThemeFamilyClick}
+                        selected={this.state.family}
+                        appearance="toggle"
+                      >
+                        Enterprise Theme
                       </Switch>{" "}
                       <Heading level={3}>Playback Speed:</Heading>
                       <Select


### PR DESCRIPTION
Converted the homepage and documentation page to use the Prisma theme. I also added a toggle on the Timelapse control and reused the same logic Ryan had for the dark theme toggle for the family toggle so that users can use prisma theme in their dashboards (which, wouldn't affect the dashboard but the timelapse interface itself).

Personally, I am a fan of the prisma look over enterprise, but to each their own. Fits the newer Splunk aesthetic. 

One thing to note is that the homepage and documentation page still have the same background color which I don't think is the standard prisma dark background color, which can be a future add. 

Also, I did not add a toggle to the homepage to allow the user to set prisma theme right away. That as well as the rangeslider control can be up next if everyone is okay with the addition of Prisma. 